### PR TITLE
fix: nginx.conf 에서 events 블록 삭제

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,53 +1,49 @@
-events { worker_connections 1024; }
+upstream inve24_loadbalancer {
+  least_conn;
 
-http {
-  upstream inve24_loadbalancer {
-    least_conn;
+  server nestjs-1:5501 max_fails=3 fail_timeout=30s;
+  server nestjs-2:5502 max_fails=3 fail_timeout=30s;
+}
 
-    server nestjs-1:5501 max_fails=3 fail_timeout=30s;
-    server nestjs-2:5502 max_fails=3 fail_timeout=30s;
+server {
+  listen 443 ssl;
+
+  server_name inve24.com;
+
+  location / {
+    proxy_pass http://inve24_loadbalancer;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $server_name;
   }
 
-  server {
-    listen 443 ssl;
+  # location /riot.txt {
+  #   root /var/www/riot;
+  #   index riot.txt;
+  # }
 
-    server_name inve24.com;
+  # mapped to ec2 /cert
+  ssl_certificate /etc/nginx/cert/fullchain.pem;
+  ssl_certificate_key /etc/nginx/cert/privkey.pem;
+  include /etc/nginx/cert/options-ssl-nginx.conf;
+  ssl_dhparam /etc/nginx/cert/ssl-dhparams.pem;
 
-    location / {
-      proxy_pass http://inve24_loadbalancer;
+  # ssl_certificate /etc/letsencrypt/live/inve24.com/fullchain.pem; # managed by Certbot
+  # ssl_certificate_key /etc/letsencrypt/live/inve24.com/privkey.pem; # managed by Certbot
+  # include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+  # ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
 
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Host $server_name;
-    }
+server {
+  listen 80;
 
-    # location /riot.txt {
-    #   root /var/www/riot;
-    #   index riot.txt;
-    # }
+  server_name inve24.com;
 
-    # mapped to ec2 /cert
-    ssl_certificate /etc/nginx/cert/fullchain.pem;
-    ssl_certificate_key /etc/nginx/cert/privkey.pem;
-    include /etc/nginx/cert/options-ssl-nginx.conf;
-    ssl_dhparam /etc/nginx/cert/ssl-dhparams.pem;
-
-    # ssl_certificate /etc/letsencrypt/live/inve24.com/fullchain.pem; # managed by Certbot
-    # ssl_certificate_key /etc/letsencrypt/live/inve24.com/privkey.pem; # managed by Certbot
-    # include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-    # ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+  if ($host = inve24.com) {
+      return 301 https://$host$request_uri;
   }
 
-  server {
-    listen 80;
-
-    server_name inve24.com;
-
-    if ($host = inve24.com) {
-        return 301 https://$host$request_uri;
-    }
-
-    return 404;
-  }
+  return 404;
 }


### PR DESCRIPTION
- 해당 커스텀 nginx.conf 파일을 default.conf 에다가 붙여널으면 events나 worker processes 등 같은 지시자를 사용하지 못함
- 따라서 http 블록 안쪽을 구성해야함