### PR TITLE
feat: 탄력적IP로 서버 접근 차단 스크립트 작성

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,15 +9,15 @@ server {
 
   server_name inve24.com;
 
-  location / {
+  # location / {
+  #     return 301 https://$host$request_uri;
+  # }
+
+  if ($host = inve24.com) {
       return 301 https://$host$request_uri;
   }
 
-  # location = /favicon.ico {
-  #     return 204;
-  #     access_log off;
-  #     log_not_found off;
-  # }
+  return 404;
 }
 
 server {
@@ -32,14 +32,6 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     # proxy_set_header X-Forwarded-Host $server_name;
-
-    # proxy_read_timeout 600s;
-    # proxy_send_timeout 600s;
-    # proxy_connect_timeout 300s;
-
-    # proxy_buffer_size 128k;
-    # proxy_buffers 4 256k;
-    # proxy_busy_buffers_size 256k;
   }
 
   # location /riot.txt {
@@ -52,9 +44,4 @@ server {
   ssl_certificate_key /etc/nginx/cert/privkey.pem;
   include /etc/nginx/cert/options-ssl-nginx.conf;
   ssl_dhparam /etc/nginx/cert/ssl-dhparams.pem;
-
-  # ssl_certificate /etc/letsencrypt/live/inve24.com/fullchain.pem; # managed by Certbot
-  # ssl_certificate_key /etc/letsencrypt/live/inve24.com/privkey.pem; # managed by Certbot
-  # include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-  # ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 }


### PR DESCRIPTION
- 도메인으로만 접근할 수 있음.
- IP접근은 SSL인증이 안되기때문
- 만약 들어오면 nginx 404를 반환함

추가) 디버깅용 명령어 제거